### PR TITLE
Fix API group for Kubernetes StorageClass resources

### DIFF
--- a/deployster.iml
+++ b/deployster.iml
@@ -4,6 +4,8 @@
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/resources/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
     </content>
     <orderEntry type="jdk" jdkName="Python 3.6 (kfirs/deployster)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/docs/builtin-resources.md
+++ b/docs/builtin-resources.md
@@ -1,3 +1,7 @@
 # Built-in resource types
 
 TBD.
+
+## GCP Project
+
+- You must manually enable `cloudresourcemanager.googleapis.com` & `cloudbilling.googleapis.com` APIs on your organization. This is due to a chicken & egg problem (we can't enable or inspect your project without those APIs enabled).

--- a/resources/src/k8s.py
+++ b/resources/src/k8s.py
@@ -108,7 +108,8 @@ class K8sResource(DResource):
 
     @action
     def create(self, args) -> None:
-        if args: pass
+        if args:
+            pass
         start_ms: int = int(round(time.time() * 1000))
         self.svc.create_k8s_object(self.build_kubectl_manifest(), self.timeout_ms, self.info.verbose)
         finish_ms: int = int(round(time.time() * 1000))
@@ -121,7 +122,8 @@ class K8sResource(DResource):
 
     @action
     def update(self, args) -> None:
-        if args: pass
+        if args:
+            pass
         start_ms: int = int(round(time.time() * 1000))
         self.svc.update_k8s_object(self.build_kubectl_manifest(), self.timeout_ms, self.info.verbose)
         finish_ms: int = int(round(time.time() * 1000))

--- a/resources/src/k8s_main.py
+++ b/resources/src/k8s_main.py
@@ -132,7 +132,7 @@ def main():
         },
         'kfirz/deployster-k8s-storageclass': {
             'kind': 'StorageClass',
-            'api_version': 'storage/v1',
+            'api_version': 'storage.k8s.io/v1',
             'factory': K8sResource
         },
     }


### PR DESCRIPTION
Deployster assumed an incorrect API group for `StorageClass` Kubernetes resources.

Fixed from `storage` to `storage.k8s.io`.