### PR TITLE
Force updates to Kubernetes StatefulSet(s)

### DIFF
--- a/resources/src/external_services.py
+++ b/resources/src/external_services.py
@@ -584,10 +584,11 @@ class ExternalServices:
                        timeout=timeout,
                        shell=True)
 
-    def update_k8s_object(self, manifest: dict, timeout: int = 60 * 5, verbose: bool = False) -> None:
+    def update_k8s_object(self, manifest: dict, timeout: int = 60 * 5, force: bool = False, verbose: bool = False) \
+            -> None:
         if verbose:
             print(f"Updating Kubernetes object from:\n{json.dumps(manifest, indent=2)}")
-        subprocess.run(f"kubectl apply -f -",
+        subprocess.run(f"kubectl apply --force={'true' if force else 'false'} -f -",
                        input=json.dumps(manifest),
                        encoding='utf-8',
                        check=True,

--- a/resources/src/k8s.py
+++ b/resources/src/k8s.py
@@ -67,6 +67,10 @@ class K8sResource(DResource):
     def timeout_interval_ms(self) -> int:
         return self.info.config['timeout_interval_ms'] if 'timeout_interval_ms' in self.info.config else 100
 
+    @property
+    def force_update(self) -> bool:
+        return False
+
     def discover_state(self):
         if 'namespace' in self.info.config['manifest']['metadata']:
             return self.svc.find_k8s_namespace_object(self.info.config['manifest'])

--- a/resources/src/k8s_main.py
+++ b/resources/src/k8s_main.py
@@ -9,6 +9,7 @@ from k8s_deployment import K8sDeployment
 from k8s_ingress import K8sIngress
 from k8s_secret import K8sSecret
 from k8s_service import K8sService
+from k8s_statefulset import K8sStatefulSet
 
 
 def main():
@@ -128,7 +129,7 @@ def main():
         'kfirz/deployster-k8s-statefulset': {
             'kind': 'StatefulSet',
             'api_version': 'apps/v1beta2',
-            'factory': K8sResource
+            'factory': K8sStatefulSet
         },
         'kfirz/deployster-k8s-storageclass': {
             'kind': 'StorageClass',

--- a/resources/src/k8s_statefulset.py
+++ b/resources/src/k8s_statefulset.py
@@ -1,0 +1,14 @@
+from external_services import ExternalServices
+from k8s import K8sResource
+
+
+class K8sStatefulSet(K8sResource):
+
+    def __init__(self, data: dict, svc: ExternalServices = ExternalServices()) -> None:
+        super().__init__(data=data, svc=svc)
+
+    @property
+    def force_update(self) -> bool:
+        # unfortunately StatefulSet only allows updating a small subset of its fields (eg. you can't add new volumes!)
+        # therefor, if the update operation's PATCH fails for 5 times, the statefulset will be recreated (force=true)
+        return True

--- a/tests/mock_external_services.py
+++ b/tests/mock_external_services.py
@@ -274,7 +274,7 @@ class MockExternalServices(ExternalServices):
             duration: int = self._k8s_create_times[key]
             time.sleep(duration / 1000)
 
-    def update_k8s_object(self, manifest: dict, timeout: int = 60 * 5, verbose: bool = True) -> None:
+    def update_k8s_object(self, manifest: dict, timeout: int = 60 * 5, force: bool = False, verbose: bool = True) -> None:
         api_version: str = manifest["apiVersion"]
         kind: str = manifest["kind"]
         metadata: dict = manifest["metadata"]


### PR DESCRIPTION
Currently, Kubernetes StatefulSet objects only allow updating a small subset of fields. For instance, you can't add or remove a volume-claim.

Until they support a broader set of fields allowed for updating, Deployster will use `kubectl`'s `--force=true` flag to recreate the stateful-sets.