### PR TITLE
Support explicitly disabling interactivity & TTY Docker flags

### DIFF
--- a/deployster.sh
+++ b/deployster.sh
@@ -14,7 +14,8 @@ WORKSPACE_DIR="$(pwd)"
 WORK_DIR="$(mkdir -p ./work; cd ./work; pwd)"
 
 # set Docker flags
-[[ -t 1 ]] && TTY_FLAGS="${TTY_FLAGS} -it"
+[[ -t 1 && "${TTY}" != "false" && "${TTY}" != "0" && "${TTY}" != "off" && "${TTY}" != "no" ]] && \
+    TTY_FLAGS="${TTY_FLAGS} -it"
 
 # run!
 docker run ${TTY_FLAGS} \


### PR DESCRIPTION
Currently, "deployster.sh" sends the "--interactive" and "--tty" flags to "docker run" if it believes that the script is running in a terminal. However, since the test is not perfect, it makes sense to allow the caller to disable those flags explicitly.

Thus the caller can set the "TTY" environment variable to "false", "0", "off" or "no" and these flags WILL NOT be sent to "docker run".
